### PR TITLE
Fix flycheck error when no Cask file is found

### DIFF
--- a/flycheck-elsa.el
+++ b/flycheck-elsa.el
@@ -61,7 +61,8 @@ listed as a dependency."
 (defun flycheck-elsa--working-directory (&rest _)
   "Return the working directory where the checker should run."
   (if (buffer-file-name)
-      (file-name-directory (locate-dominating-file (buffer-file-name) "Cask"))
+      (when-let (file (locate-dominating-file (buffer-file-name) "Cask"))
+        (file-name-directory file))
     default-directory))
 
 (flycheck-define-checker emacs-lisp-elsa


### PR DESCRIPTION
Without this, attempting to enable flycheck on an emacs lisp file without Cask
would throw a `(wrong-type-argument stringp nil)` error instead of selecting the
next best available checker.