### PR TITLE
fix package-lint warnings

### DIFF
--- a/Cask
+++ b/Cask
@@ -3,9 +3,7 @@
 
 (package "flycheck-elsa" "1.0.0" "Flycheck for Elsa.")
 
-(depends-on "cask" "0.8.4")
-(depends-on "seq" "2.0")
-(depends-on "emacs" "25")
+(package-file "flycheck-elsa.el")
 
 (development
  (depends-on "trinary" "0.0.1")

--- a/flycheck-elsa.el
+++ b/flycheck-elsa.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 1.0.0
 ;; Created: 23rd August 2018
-;; Package-requires: ((emacs "25") (seq "2.0") (cask "0.8.4"))
+;; Package-requires: ((emacs "25.1") (seq "2.0") (cask "0.8.4"))
 ;; Keywords: convenience
 ;; Homepage: https://github.com/emacs-elsa/flycheck-elsa
 
@@ -39,9 +39,7 @@
   :group 'flycheck
   :link '(url-link :tag "Github" "https://github.com/emacs-elsa/flycheck-elsa"))
 
-(defcustom flycheck-elsa-ignored-files-regexps '(
-                                                 "\\`Cask\\'"
-                                                 )
+(defcustom flycheck-elsa-ignored-files-regexps '("\\`Cask\\'")
   "List of regular expressions matching files which should be ignored by Elsa."
   :group 'flycheck-elsa
   :type '(repeat regexp))


### PR DESCRIPTION
Hi!
I found package-lint warnigns, I fix it.

Note:
I fix Cask file dependency.
Because this change, Cask resolve dependency form `Package-requires: `
header writen in `flycheck-elsa.el`.
This scheme in line with the idea known for DRY.