### PR TITLE
Remove cask dependency

### DIFF
--- a/Cask
+++ b/Cask
@@ -3,7 +3,6 @@
 
 (package "flycheck-elsa" "1.0.0" "Flycheck for Elsa.")
 
-(depends-on "cask" "0.8.4")
 (depends-on "seq" "2.0")
 (depends-on "emacs" "25")
 

--- a/flycheck-elsa.el
+++ b/flycheck-elsa.el
@@ -45,6 +45,11 @@
   :group 'flycheck-elsa
   :type '(repeat regexp))
 
+(defun flycheck-elsa--locate-cask-dir ()
+  "Return dir located Cask file.  If missing, return nil."
+  (when-let (file (locate-dominating-file (buffer-file-name) "Cask"))
+    (file-name-directory file)))
+
 (defun flycheck-elsa--enable-p ()
   "Return non-nil if we can enable Elsa in current buffer.
 
@@ -58,8 +63,7 @@ listed as a dependency."
 (defun flycheck-elsa--working-directory (&rest _)
   "Return the working directory where the checker should run."
   (if (buffer-file-name)
-      (when-let (file (locate-dominating-file (buffer-file-name) "Cask"))
-        (file-name-directory file))
+      (flycheck-elsa--locate-cask-dir)
     default-directory))
 
 (flycheck-define-checker emacs-lisp-elsa

--- a/flycheck-elsa.el
+++ b/flycheck-elsa.el
@@ -81,11 +81,7 @@ listed as a dependency."
       (and (buffer-file-name)
            (not (seq-find (lambda (f) (string-match-p f (buffer-file-name)))
                           flycheck-elsa-ignored-files-regexps))
-           (and (flycheck-elsa--elsa-dependency-p)
-                (if (= 0 (call-process "cask" nil nil nil "exec" "elsa" "-h"))
-                    t
-                  (warn "Your Cask file have elsa dependency, but failed exec elsa")
-                  nil))))))
+           (flycheck-elsa--elsa-dependency-p)))))
 
 (defun flycheck-elsa--working-directory (&rest _)
   "Return the working directory where the checker should run."

--- a/flycheck-elsa.el
+++ b/flycheck-elsa.el
@@ -55,10 +55,12 @@
 
 We require that the project is managed by Cask and that Elsa is
 listed as a dependency."
-  (and (buffer-file-name)
-       (not (seq-find (lambda (f) (string-match-p f (buffer-file-name)))
-                      flycheck-elsa-ignored-files-regexps))
-       (= 0 (call-process "cask" nil nil nil "exec" "elsa" "-h"))))
+  (when-let (cask-dir (flycheck-elsa--locate-cask-dir))
+    (let ((default-directory cask-dir))
+      (and (buffer-file-name)
+           (not (seq-find (lambda (f) (string-match-p f (buffer-file-name)))
+                          flycheck-elsa-ignored-files-regexps))
+           (= 0 (call-process "cask" nil nil nil "exec" "elsa" "-h"))))))
 
 (defun flycheck-elsa--working-directory (&rest _)
   "Return the working directory where the checker should run."

--- a/flycheck-elsa.el
+++ b/flycheck-elsa.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Version: 1.0.0
 ;; Created: 23rd August 2018
-;; Package-requires: ((emacs "25") (seq "2.0") (cask "0.8.4"))
+;; Package-requires: ((emacs "25") (seq "2.0"))
 ;; Keywords: convenience
 ;; Homepage: https://github.com/emacs-elsa/flycheck-elsa
 
@@ -30,7 +30,6 @@
 ;;; Code:
 
 (require 'flycheck)
-(require 'cask)
 (require 'seq)
 
 (defgroup flycheck-elsa nil
@@ -51,12 +50,10 @@
 
 We require that the project is managed by Cask and that Elsa is
 listed as a dependency."
-  (when (and (buffer-file-name)
-             (not (seq-find (lambda (f) (string-match-p f (buffer-file-name)))
-                            flycheck-elsa-ignored-files-regexps)))
-    (when-let ((cask-file (locate-dominating-file (buffer-file-name) "Cask")))
-      (let ((bundle (cask-initialize (file-name-directory cask-file))))
-        (cask-find-dependency bundle 'elsa)))))
+  (and (buffer-file-name)
+       (not (seq-find (lambda (f) (string-match-p f (buffer-file-name)))
+                      flycheck-elsa-ignored-files-regexps))
+       (= 0 (call-process "cask" nil nil nil "exec" "elsa" "-h"))))
 
 (defun flycheck-elsa--working-directory (&rest _)
   "Return the working directory where the checker should run."


### PR DESCRIPTION
Remove cask dependency.
Use `cask exec elsa -h` to test elsa available.

This change fixes #8 and fixes #9.