### PR TITLE
dominating-file when exist buffer-file-name

### DIFF
--- a/flycheck-elsa.el
+++ b/flycheck-elsa.el
@@ -47,7 +47,8 @@
 
 (defun flycheck-elsa--locate-cask-dir ()
   "Return dir located Cask file.  If missing, return nil."
-  (when-let (file (locate-dominating-file (buffer-file-name) "Cask"))
+  (when-let ((filename (buffer-file-name))
+             (file (locate-dominating-file filename "Cask")))
     (file-name-directory file)))
 
 (defun flycheck-elsa--elsa-dependency-p ()


### PR DESCRIPTION
Hi!
I found `locate-dominating-file` occur error when first argument is nil.
I fix that issue.

## Backtrace

``` emacs-lisp
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  expand-file-name(nil)
  locate-dominating-file(nil "Cask")
  flycheck-elsa--locate-cask-dir()
  flycheck-elsa--enable-p()
  #f(compiled-function () #<bytecode 0x18da90d>)()
  funcall(#f(compiled-function () #<bytecode 0x18da90d>))
  (or (null predicate) (funcall predicate))
  (and (flycheck-valid-checker-p checker) (flycheck-checker-supports-major-mo
  (let ((predicate (flycheck-checker-get checker (quote predicate)))) (and (f
  flycheck-may-use-checker(emacs-lisp-elsa)
  #f(compiled-function (elt) #<bytecode 0x18cdecd>)(emacs-lisp-elsa)
  mapc(#f(compiled-function (elt) #<bytecode 0x18cdecd>) (tsx-tide typescript
  seq-do(#f(compiled-function (elt) #<bytecode 0x18cdecd>) (tsx-tide typescri
  seq-find(flycheck-may-use-checker (tsx-tide typescript-tide emacs-lisp-elsa
  (if flycheck-checker (if (flycheck-may-use-checker flycheck-checker) (progn
  flycheck-get-checker-for-buffer()
  eval((flycheck-get-checker-for-buffer) nil)
  eval-expression((flycheck-get-checker-for-buffer) nil nil 127)
  funcall-interactively(eval-expression (flycheck-get-checker-for-buffer) nil
  call-interactively(eval-expression nil nil)
  command-execute(eval-expression)
```