### PR TITLE
fix: Warning missing lexical-binding cookie

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,6 @@ jobs:
         - os: windows-latest
           emacs-version: snapshot
           experimental: true
-        exclude:
-          - os: macos-latest
-            emacs-version: 26.3
-          - os: macos-latest
-            emacs-version: 27.2
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,32 +14,39 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 26.3
-          - 27.2
           - 28.2
-          - snapshot
+          - 29.4
+          - 30.1
+        experimental: [false]
+        include:
+        - os: ubuntu-latest
+          emacs-version: snapshot
+          experimental: true
+        - os: macos-latest
+          emacs-version: snapshot
+          experimental: true
+        - os: windows-latest
+          emacs-version: snapshot
+          experimental: true
+        exclude:
+          - os: macos-latest
+            emacs-version: 26.3
+          - os: macos-latest
+            emacs-version: 27.2
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: jcs090218/setup-emacs@master
       with:
         version: ${{ matrix.emacs-version }}
-        
-    # Remove expired DST Root CA X3 certificate. Workaround for
-    # https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51038 bug on Emacs 27.x or lower.
-    # https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-1126671598
-    - name: Workaround for Emacs 27.x or lower's Windows build from GNU FTP
-      if: ${{ runner.os == 'Windows' && (matrix.emacs-version == '26.3' || matrix.emacs-version == '27.2') }}
-      run: |
-        gci cert:\LocalMachine\Root\DAC9024F54D8F6DF94935FB1732638CA6AD77C13
-        gci cert:\LocalMachine\Root\DAC9024F54D8F6DF94935FB1732638CA6AD77C13 | Remove-Item
-        
+
     - uses: emacs-eask/setup-eask@master
       with:
         version: 'snapshot'

--- a/Eask
+++ b/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "flycheck-elsa" "1.0.0" "Flycheck for Elsa")
 
 (website-url "https://github.com/emacs-elsa/flycheck-elsa")


### PR DESCRIPTION
Fix snapshot warning:

```
You can add one with ‘M-x elisp-enable-lexical-binding RET’.
See ‘(elisp)Selecting Lisp Dialect’ and ‘(elisp)Converting to Lexical Binding’
for more information.
```